### PR TITLE
Fixes #2: Remove title when inbox count is 0

### DIFF
--- a/Sources/MyStreamDeckPlugin.m
+++ b/Sources/MyStreamDeckPlugin.m
@@ -230,7 +230,7 @@ static NSString * CreateBase64EncodedString(NSString *inImagePath)
 		else if(numberOfUnreadEmails == 0)
 		{
 			[self.connectionManager setImage:self.base64MailIconString withContext:context withTarget:kESDSDKTarget_HardwareAndSoftware];
-			[self.connectionManager setTitle:nil withContext:context withTarget:kESDSDKTarget_HardwareAndSoftware];
+			[self.connectionManager setTitle:@"" withContext:context withTarget:kESDSDKTarget_HardwareAndSoftware];
 		}
 		else
 		{


### PR DESCRIPTION
Setting the title to nil does not clear out the current value.
If the unread email count is 0 we set the title to an empty string so it doesn't show a value over the icon.